### PR TITLE
 Less confusing message for PKINIT configuration during install

### DIFF
--- a/ipaserver/install/krbinstance.py
+++ b/ipaserver/install/krbinstance.py
@@ -502,8 +502,17 @@ class KrbInstance(service.Service):
             self._install_pkinit_ca_bundle()
             self.pkinit_enable()
         except RuntimeError as e:
-            logger.error("PKINIT certificate request failed: %s", e)
-            logger.error("Failed to configure PKINIT")
+            logger.warning("PKINIT certificate request failed: %s", e)
+            logger.warning("Failed to configure PKINIT")
+
+            self.print_msg("Full PKINIT configuration did not succeed")
+            self.print_msg(
+                "The setup will only install bits "
+                "essential to the server functionality")
+            self.print_msg(
+                "You can enable PKINIT after the "
+                "setup completed using 'ipa-pkinit-manage'")
+
             self.stop_tracking_certs()
             self.issue_selfsigned_pkinit_certs()
 


### PR DESCRIPTION
The message about an error during replica setup was causing the
users to think the installation gone wrong even though this was
an expected behavior when ipa-replica-install was ran without
--no-pkinit flag and CA somehow is not reachable which defines
that there is something wrong in a topology but does not lead
to failure of the replica's installation. So now installation
will not print error messages to stdout but rather will give a
recomendation to user and write the old error message to log
as a warning so it still will be easy to find if needed.

https://pagure.io/freeipa/issue/7179