### PR TITLE
Make tox tests to generate results in JUnit XML

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
     ipatests
 commands=
     {envbindir}/ipa --help
-    {envpython} -bb {envbindir}/ipa-run-tests --ipaclient-unittests
+    {envpython} -bb {envbindir}/ipa-run-tests --ipaclient-unittests --junitxml={envdir}/junit-{envname}.xml
 
 [testenv:pylint2]
 basepython=python2.7


### PR DESCRIPTION
As our tox runs pytest it's great to have their results in JUnit
format for later processing.